### PR TITLE
remove unneeded imports

### DIFF
--- a/contracts/JBV1TokenPaymentTerminal.sol
+++ b/contracts/JBV1TokenPaymentTerminal.sol
@@ -1,12 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.6;
 
-import '@jbx-protocol/contracts-v2/contracts/abstract/JBOperatable.sol';
 import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBController.sol';
 import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBPaymentTerminal.sol';
-import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBRedemptionTerminal.sol';
-import '@jbx-protocol/contracts-v2/contracts/libraries/JBOperations.sol';
-import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import './interfaces/IJBV1TokenPaymentTerminal.sol';
 
@@ -35,7 +31,7 @@ import './interfaces/IJBV1TokenPaymentTerminal.sol';
   Inherits from -
   JBOperatable: Several functions in this contract can only be accessed by a project owner, or an address that has been preconfifigured to be an operator of the project.
 */
-contract JBV1TokenPaymentTerminal is IJBV1TokenPaymentTerminal, IJBPaymentTerminal, JBOperatable {
+contract JBV1TokenPaymentTerminal is IJBV1TokenPaymentTerminal, IJBPaymentTerminal {
   //*********************************************************************//
   // --------------------------- custom errors ------------------------- //
   //*********************************************************************//
@@ -184,8 +180,7 @@ contract JBV1TokenPaymentTerminal is IJBV1TokenPaymentTerminal, IJBPaymentTermin
   function supportsInterface(bytes4 _interfaceId) external pure override returns (bool) {
     return
       _interfaceId == type(IJBPaymentTerminal).interfaceId ||
-      _interfaceId == type(IJBV1TokenPaymentTerminal).interfaceId ||
-      _interfaceId == type(IJBOperatable).interfaceId;
+      _interfaceId == type(IJBV1TokenPaymentTerminal).interfaceId;
   }
 
   //*********************************************************************//
@@ -193,17 +188,15 @@ contract JBV1TokenPaymentTerminal is IJBV1TokenPaymentTerminal, IJBPaymentTermin
   //*********************************************************************//
 
   /**
-    @param _operatorStore A contract storing operator assignments.
     @param _projects A contract which mints ERC-721's that represent project ownership and transfers.
     @param _directory A contract storing directories of terminals and controllers for each project.
     @param _ticketBooth The V1 contract where tokens are stored.
   */
   constructor(
-    IJBOperatorStore _operatorStore,
     IJBProjects _projects,
     IJBDirectory _directory,
     ITicketBooth _ticketBooth
-  ) JBOperatable(_operatorStore) {
+  ) {
     projects = _projects;
     directory = _directory;
     ticketBooth = _ticketBooth;

--- a/contracts/JBV1TokenPaymentTerminal.sol
+++ b/contracts/JBV1TokenPaymentTerminal.sol
@@ -26,10 +26,6 @@ import './interfaces/IJBV1TokenPaymentTerminal.sol';
   Adheres to -
   IJBV1TokenPaymentTerminal: General interface for the methods in this contract that interact with the blockchain's state according to the protocol's rules.
   IJBPaymentTerminal: Standardized interface for project to receive payments.
-
-  @dev
-  Inherits from -
-  JBOperatable: Several functions in this contract can only be accessed by a project owner, or an address that has been preconfifigured to be an operator of the project.
 */
 contract JBV1TokenPaymentTerminal is IJBV1TokenPaymentTerminal, IJBPaymentTerminal {
   //*********************************************************************//

--- a/contracts/interfaces/IJBV1TokenPaymentTerminal.sol
+++ b/contracts/interfaces/IJBV1TokenPaymentTerminal.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.6;
 
-import '@jbox/sol/contracts/TicketBooth.sol';
+import '@jbox/sol/contracts/interfaces/ITicketBooth.sol';
 import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBDirectory.sol';
 import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBProjects.sol';
 

--- a/contracts/scripts/Deploy.sol
+++ b/contracts/scripts/Deploy.sol
@@ -8,7 +8,7 @@ import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBOperatorStore.sol';
 import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBProjects.sol';
 import '@jbx-protocol/contracts-v1/contracts/interfaces/ITicketBooth.sol';
 
-contract Deploy is Test {
+contract DeployRinkeby is Test {
   IJBOperatorStore _operatorStore = IJBOperatorStore(0xEDB2db4b82A4D4956C3B4aA474F7ddf3Ac73c5AB);
   IJBProjects _projects = IJBProjects(0x2d8e361f8F1B5daF33fDb2C99971b33503E60EEE);
   IJBDirectory _directory = IJBDirectory(0x1A9b04A9617ba5C9b7EBfF9668C30F41db6fC21a);
@@ -22,7 +22,6 @@ contract Deploy is Test {
     vm.startBroadcast();
 
     migrationTerminal = new JBV1TokenPaymentTerminal(
-      _operatorStore,
       _projects,
       _directory,
       _ticketBooth

--- a/contracts/tests/e2e/JBV1TokenPaymentTerminal.t.sol
+++ b/contracts/tests/e2e/JBV1TokenPaymentTerminal.t.sol
@@ -14,7 +14,6 @@ contract TestE2EJBV1TokenPaymentTerminal is TestBaseWorkflow {
 
     // Create new migration terminal
     migrationTerminal = new JBV1TokenPaymentTerminal(
-      _jbOperatorStore,
       _jbProjects,
       _jbDirectory,
       _ticketBoothV1

--- a/contracts/tests/units/JBV1TokenPaymentTerminal.t.sol
+++ b/contracts/tests/units/JBV1TokenPaymentTerminal.t.sol
@@ -48,7 +48,6 @@ contract TestUnitJBV1TokenPaymentTerminal is Test {
   JBV1TokenPaymentTerminal migrationTerminal;
 
   function setUp() public {
-    mockOperatorStore = IJBOperatorStore(address(10));
     mockProjects = IJBProjects(address(20));
     mockDirectory = IJBDirectory(address(30));
     mockTicketBooth = ITicketBooth(address(40));
@@ -59,7 +58,6 @@ contract TestUnitJBV1TokenPaymentTerminal is Test {
     caller = address(420);
     beneficiary = address(6942069);
 
-    vm.etch(address(mockOperatorStore), new bytes(0x69));
     vm.etch(address(mockProjects), new bytes(0x69));
     vm.etch(address(mockProjectsV1), new bytes(0x69));
     vm.etch(address(mockDirectory), new bytes(0x69));
@@ -67,7 +65,6 @@ contract TestUnitJBV1TokenPaymentTerminal is Test {
     vm.etch(address(mockV1JBToken), new bytes(0x69));
     vm.etch(address(mockController), new bytes(0x69));
 
-    vm.label(address(mockOperatorStore), 'mockOperatorStore');
     vm.label(address(mockProjects), 'mockProjects');
     vm.label(address(mockProjectsV1), 'mockProjectsV1');
     vm.label(address(mockDirectory), 'mockDirectory');
@@ -79,7 +76,6 @@ contract TestUnitJBV1TokenPaymentTerminal is Test {
     vm.label(beneficiary, 'beneficiary');
 
     migrationTerminal = new JBV1TokenPaymentTerminal(
-      mockOperatorStore,
       mockProjects,
       mockDirectory,
       mockTicketBooth


### PR DESCRIPTION
quick cleanup

Verification via `--verify` still fails (but work using `forge flatten ./contracts/JBV1TokenPaymentTerminal.sol --out flat.sol` then doing it via etherscan UI)